### PR TITLE
Add a form for sponsor invoice informations

### DIFF
--- a/src/components/moneiz/SponsorInvoiceInfoForm.vue
+++ b/src/components/moneiz/SponsorInvoiceInfoForm.vue
@@ -1,0 +1,88 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+
+import { newSponsor, type Sponsor } from '@/dto/moneiz/Sponsor';
+
+const props = defineProps<{
+  modelValue: Sponsor | undefined;
+  disabled: boolean;
+}>();
+
+const emit = defineEmits<{
+  'update:modelValue': [value: Sponsor];
+}>();
+
+const localSponsor = computed({
+  get: () => props.modelValue ?? newSponsor(),
+  set: (value) => { emit('update:modelValue', value); },
+});
+</script>
+
+<template>
+  <div class="card h-100">
+    <div class="card-body">
+      <h5 class="card-title mb-3">Informations de facturation</h5>
+      <form @submit.prevent>
+        <div class="row mb-3">
+          <label for="invoice-name" class="col-sm-3 col-form-label">
+            Raison sociale
+          </label>
+          <div class="col-sm-9">
+            <input
+              id="invoice-name"
+              type="text"
+              class="form-control"
+              v-model="localSponsor.invoiceName"
+              :disabled="disabled"
+            />
+          </div>
+        </div>
+
+        <div class="row mb-3">
+          <label for="address" class="col-sm-3 col-form-label">
+            Adresse
+          </label>
+          <div class="col-sm-9">
+            <textarea
+              id="address"
+              class="form-control"
+              rows="4"
+              v-model="localSponsor.address"
+              :disabled="disabled"
+            />
+          </div>
+        </div>
+
+        <div class="row mb-3">
+          <label for="vat-id" class="col-sm-3 col-form-label">
+            Numéro de TVA
+          </label>
+          <div class="col-sm-9">
+            <input
+              id="vat-id"
+              type="text"
+              class="form-control"
+              v-model="localSponsor.vatId"
+              :disabled="disabled"
+            />
+          </div>
+        </div>
+
+        <div class="row mb-3">
+          <label for="siret" class="col-sm-3 col-form-label">
+            Siret
+          </label>
+          <div class="col-sm-9">
+            <input
+              id="siret"
+              type="text"
+              class="form-control"
+              v-model="localSponsor.siret"
+              :disabled="disabled"
+            />
+          </div>
+        </div>
+      </form>
+    </div>
+  </div>
+</template>

--- a/src/dto/moneiz/Sponsor.ts
+++ b/src/dto/moneiz/Sponsor.ts
@@ -3,9 +3,13 @@ export type Sponsor = {
   token: string;
   url?: string;
   logo?: string;
+  invoiceName?: string;
+  address?: string;
+  vatId?: string;
+  siret?: string;
 };
 
-export function newSponsor() {
+export function newSponsor(): Sponsor {
   return {
     name: '',
     token: '',

--- a/src/views/moneiz/SponsorEditView.vue
+++ b/src/views/moneiz/SponsorEditView.vue
@@ -3,6 +3,7 @@ import { computed, ref, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 
 import SponsorBasicInfoForm from '@/components/moneiz/SponsorBasicInfoForm.vue';
+import SponsorInvoiceInfoForm from '@/components/moneiz/SponsorInvoiceInfoForm.vue';
 import type { Sponsor } from '@/dto/moneiz/Sponsor';
 import { getSponsor, useCreateSponsorMutation, useUpdateSponsorMutation, useUploadSponsorLogoMutation } from '@/queries/moneiz/sponsors.queries';
 
@@ -108,12 +109,10 @@ const saveSponsor = async () => {
 
       <!-- Invoice Info Section (placeholder) -->
       <div class="grid-invoice-info">
-        <div class="card h-100">
-          <div class="card-body">
-            <h5 class="card-title mb-3">Informations de facturation</h5>
-            <p class="text-muted"><i>À venir...</i></p>
-          </div>
-        </div>
+        <SponsorInvoiceInfoForm
+          v-model="sponsor"
+          :disabled="disabled"
+        />
       </div>
 
       <!-- Contacts Section (placeholder) -->


### PR DESCRIPTION
Add a form to edit the sponsor's invoice informations like the one already existing in Moneiz.

<img width="845" height="556" alt="Capture d’écran du 2026-05-15 11-01-28" src="https://github.com/user-attachments/assets/1614af6b-1b5e-4baf-ac87-6cb2ad0bb66e" />

Requires: https://github.com/breizhcamp/moneiz/pull/8